### PR TITLE
Add a local-only "play-test" mode

### DIFF
--- a/dist/rally-content.js
+++ b/dist/rally-content.js
@@ -7569,6 +7569,7 @@ var webMessages;
     webMessages["COMPLETE_SIGNUP"] = "rally-sdk.complete-signup";
     webMessages["WEB_CHECK_RESPONSE"] = "rally-sdk.web-check-response";
     webMessages["COMPLETE_SIGNUP_RESPONSE"] = "rally-sdk.complete-signup-response";
+    webMessages["CHANGE_STATE"] = "rally-sdk.change-state";
 })(webMessages || (webMessages = {}));
 
 /* This Source Code Form is subject to the terms of the Mozilla Public

--- a/tests/unit/rally.test.ts
+++ b/tests/unit/rally.test.ts
@@ -118,19 +118,20 @@ describe('Rally SDK', function () {
     let pausedCallbackCalled = false;
     let resumeCallbackCalled = false;
 
-    const rally = new Rally(
-      true, // Developer mode.
-      (message) => {
+    const rally = new Rally({
+      enableDevMode: false,
+      stateChangeCallback: (message) => {
         if (message === runStates.PAUSED) {
           pausedCallbackCalled = true;
         } else if (message === runStates.RUNNING) {
           resumeCallbackCalled = true;
         }
       },
-      "http://localhost",
-      "exampleStudy1",
-      {}
-    )
+      rallySite: "http://localhost",
+      studyId: "exampleStudy1",
+      firebaseConfig: {},
+      enableEmulatorMode: false,
+    })
 
     assert.equal(rally._state, runStates.PAUSED);
 
@@ -148,9 +149,9 @@ describe('Rally SDK', function () {
     let resumeCallbackCalled = false;
     let endedCallbackCalled = false;
 
-    const rally = new Rally(
-      true, // Developer mode.
-      (message) => {
+    const rally = new Rally({
+      enableDevMode: false,
+      stateChangeCallback: (message) => {
         if (message === runStates.PAUSED) {
           pausedCallbackCalled = true;
         } else if (message === runStates.RUNNING) {
@@ -160,10 +161,11 @@ describe('Rally SDK', function () {
         }
 
       },
-      "http://localhost",
-      "exampleStudy1",
-      {}
-    );
+      rallySite: "http://localhost",
+      studyId: "exampleStudy1",
+      firebaseConfig: {},
+      enableEmulatorMode: false
+    });
 
     const rallyToken = "...";
     const message = { type: webMessages.COMPLETE_SIGNUP_RESPONSE, data: { rallyToken } };


### PR DESCRIPTION
This splits out "developer mode" as a separate thing from "emulator mode" - the former is now fully local, and enables: https://github.com/mozilla-rally/study-template/pull/175